### PR TITLE
Fix `CstParseError` adding note twice

### DIFF
--- a/parser/error.py
+++ b/parser/error.py
@@ -20,8 +20,11 @@ class BaseLocatedError(BaseParseError):
         self.msg = msg
         self._src_text = src
         self.region = region
+        self._has_added_note = False
 
     def compute_location(self):
+        if self._has_added_note:
+            return
         # noinspection PyBroadException
         try:
             self.add_note(self.display_region(self._src_text, self.region))
@@ -30,6 +33,7 @@ class BaseLocatedError(BaseParseError):
             self.add_note(
                 '\nAn error occurred while trying to display the location '
                 f'of the ParseError ({short_loc}):\n{traceback.format_exc()}')
+        self._has_added_note = True
 
     def __str__(self):
         self.compute_location()

--- a/parser/error.py
+++ b/parser/error.py
@@ -13,6 +13,8 @@ class BaseParseError(Exception):
 
 
 class BaseLocatedError(BaseParseError):
+    __notes__: list[str]  # but might not exist
+
     def __init__(self, msg: str, region: StrRegion, src: str):
         super().__init__(msg)
         self.msg = msg

--- a/test/test_error.py
+++ b/test/test_error.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import patch
+
+from parser.error import BaseLocatedError
+from parser.str_region import StrRegion
+
+
+class TestLocatedError(unittest.TestCase):
+    def test_adds_note_once(self):
+        with patch.object(BaseLocatedError, 'display_region') as mock_display:
+            mock_display.return_value = 'mock_return_value'
+            err = BaseLocatedError("a_message", StrRegion(0, 2), 'src_str')
+            str(err)
+            self.assertEqual(len(err.__notes__), 1)
+            str(err)
+            self.assertEqual(len(err.__notes__), 1)
+
+    def test_uses_display_return_value(self):
+        with patch.object(BaseLocatedError, 'display_region') as mock_display:
+            mock_display.return_value = 'mock_return_value'
+            err = BaseLocatedError("a_message", StrRegion(0, 2), 'src_str')
+            str(err)
+            mock_display.assert_called_once_with('src_str', StrRegion(0, 2))
+            self.assertEqual(err.__notes__, ['mock_return_value'])
+
+    def test_only_calls_display_when_needed(self):
+        with patch.object(BaseLocatedError, 'display_region') as mock_display:
+            mock_display.return_value = 'mock_return_value'
+            err = BaseLocatedError("a_message", StrRegion(0, 2), 'src_str')
+            mock_display.assert_not_called()
+            str(err)
+            mock_display.assert_called_once()
+            str(err)
+            mock_display.assert_called_once()  # still only once
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fix `CstParseError` adding note twice, fixes #5 