### PR TITLE
fix: Add support for Python 3.10

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -10,13 +10,18 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        py_version: 
+          - "3.10"
+          - "3.11"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Setup python 3.11
+      - name: Setup python ${{ matrix.py_version }}
         uses: actions/setup-python@v4.6.1
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.py_version }}
       - name: Run tests
         run: |
           chmod +x ./run_tests.sh

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -1,10 +1,23 @@
 import unittest
-from enum import IntFlag, FlagBoundary, IntEnum
+from enum import IntFlag, Enum
 from typing import Sequence, TypeVar, Union
 
 from parser.str_region import StrRegion
 from parser.tokenizer import Tokenizer
 from parser.tokens import IdentNameToken, Token, DotToken, AttrNameToken
+
+try:
+    from enum import FlagBoundary
+except ImportError:
+    # won't actually do anything but the kwargs will be ignored
+    # and this is only used so that 'errors never pass silently'
+    # and the bugs will be detected in 3.11 tests anyway so we just
+    # provide the expected attributes but they won't do anything
+    class FlagBoundary(Enum):
+        STRICT = 1
+        CONFORM = 2
+        EJECT = 3
+        KEEP = 4
 
 
 class TokenStreamFlag(IntFlag, boundary=FlagBoundary.STRICT):

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -1,26 +1,21 @@
 import unittest
-from enum import IntFlag, Enum
+from enum import IntFlag
 from typing import Sequence, TypeVar, Union
 
 from parser.str_region import StrRegion
 from parser.tokenizer import Tokenizer
 from parser.tokens import IdentNameToken, Token, DotToken, AttrNameToken
 
-try:
-    from enum import FlagBoundary
-except ImportError:
-    # won't actually do anything but the kwargs will be ignored
-    # and this is only used so that 'errors never pass silently'
-    # and the bugs will be detected in 3.11 tests anyway so we just
-    # provide the expected attributes but they won't do anything
-    class FlagBoundary(Enum):
-        STRICT = 1
-        CONFORM = 2
-        EJECT = 3
-        KEEP = 4
+
+def _strict_boundary_kwargs():
+    try:
+        from enum import FlagBoundary
+        return {'boundary': FlagBoundary.STRICT}
+    except ImportError:
+        return {}  # Python 3.10
 
 
-class TokenStreamFlag(IntFlag, boundary=FlagBoundary.STRICT):
+class TokenStreamFlag(IntFlag, **_strict_boundary_kwargs()):
     CONTENT = 1
     FULL = 2
     BOTH = CONTENT | FULL


### PR DESCRIPTION
- Add polyfill for `add_note` (`_polyfillAddNoteMixin`)
- Adds support for 3.10 (in theory)
- Fixes #15 

### Todo
- [x] Add workflow to test in on 3.10 (matrix strategy)