### PR TITLE
refactor: Set tree_print to append LF by default

### DIFF
--- a/parser/cst/tree_print.py
+++ b/parser/cst/tree_print.py
@@ -94,7 +94,7 @@ class TreePrinter:
 
 
 def tree_print(obj: object, stream: IO[str] = None, indent: int = 2,
-               verbose: bool = False, append_lf: bool = False):
+               verbose: bool = False, append_lf: bool = True):
     TreePrinter(stream, indent, verbose, append_lf).print(obj)
 
 


### PR DESCRIPTION
refactor: Set tree_print to append LF by default  (forgot to push to #29 before merging)