### PR TITLE
Refactor tokenizer

### DIFF
--- a/parser/common/__init__.py
+++ b/parser/common/__init__.py
@@ -1,4 +1,7 @@
 from .common import *
 from .error import *  # <^ might add some stuff so `import *`
 from .str_region import StrRegion  # <-- won't add stuff to str_region so not `import *`
-from .tree_print import *
+# IMPORTant: don't include tree_print here as that causes circular import issue:
+#  - lexer.tokens imports ..common (for StrRegion)
+#  - tree_print also loaded from common/__init__.py
+#  - tree_print needs `Node`... and `Node` needs lexer.tokens

--- a/parser/cst/base_node.py
+++ b/parser/cst/base_node.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from ..common import StrRegion, HasRegion
-from ..tokens import Token
+
+if TYPE_CHECKING:
+    from ..tokens import Token
 
 
 @dataclass

--- a/parser/lexer/__init__.py
+++ b/parser/lexer/__init__.py
@@ -1,4 +1,5 @@
-from .tokenizer import Tokenizer, print_tokens, format_tokens
+from .tokenizer import Tokenizer
+from .token_print import print_tokens, format_tokens
 from .errors import (
     TokenizerError, LocatedTokenizerError, MalformedNumberError,
     LocatedMalformedNumberError)

--- a/parser/lexer/__init__.py
+++ b/parser/lexer/__init__.py
@@ -1,5 +1,4 @@
-from .tokenizer import (
-    Tokenizer,
-    TokenizerError, LocatedTokenizerError,
-    LocatedMalformedNumberError, MalformedNumberError,
-    print_tokens, format_tokens)
+from .tokenizer import Tokenizer, print_tokens, format_tokens
+from .errors import (
+    TokenizerError, LocatedTokenizerError, MalformedNumberError,
+    LocatedMalformedNumberError)

--- a/parser/lexer/errors.py
+++ b/parser/lexer/errors.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from parser.common import BaseParseError, BaseLocatedError
+
+
+class TokenizerError(BaseParseError):
+    ...
+
+
+class LocatedTokenizerError(BaseLocatedError, TokenizerError):
+    ...
+
+
+class MalformedNumberError(TokenizerError):
+    ...
+
+
+class LocatedMalformedNumberError(LocatedTokenizerError, MalformedNumberError):
+    ...

--- a/parser/lexer/number_parser.py
+++ b/parser/lexer/number_parser.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from string import digits
+
+from parser.common import StrRegion
+from parser.lexer import LocatedMalformedNumberError
+from parser.lexer.src_handler import UsesSrc
+from parser.lexer.tokens import Token, NumberToken
+
+
+class NumberParser(UsesSrc):
+    default_err_type = LocatedMalformedNumberError
+
+    # todo 0x, 0b (I refuse to add octal literals) - also hex floats???
+    def _parse_digit_seq(self, start: int) -> int | None:
+        # (Returns None if no digits)
+        idx = start
+        if self.get(idx) == '_':
+            raise self.err("Can't have '_' at the start of a number", idx)
+        if self.get(idx) not in digits:
+            return None
+        idx += 1
+        while True:
+            if self.get(idx) == '_':
+                if self.get(idx + 1) in digits:
+                    idx += 2  # '_' and digit
+                elif self.get(idx + 1) == '_':
+                    raise self.err(
+                        "Can only have one consecutive '_' in a number", idx + 1)
+                else:
+                    raise self.err(
+                        "Can't have '_' at the end of a number", idx)
+            elif self.get(idx) in digits:
+                idx += 1
+            else:
+                return idx  # end of digits/'_'
+
+    def _parse_num_no_exp(self, idx: int) -> int:
+        new_idx = self._parse_digit_seq(idx)
+        if new_idx is None:
+            if self.get(idx) != '.':
+                raise self.err("Number must start with digit or '.' ", idx)
+            has_pre_dot = False
+        else:
+            has_pre_dot = True
+            idx = new_idx
+        if self.get(idx) != '.':
+            # eg: 1234, 567e-5, 8 +9-10
+            return idx
+        idx += 1
+        new_idx = self._parse_digit_seq(idx)
+        if new_idx is None:
+            has_post_dot = False
+        else:
+            has_post_dot = True
+            idx = new_idx
+        if has_pre_dot or has_post_dot:
+            return idx
+        raise self.err("Number cannot be a single '.' "
+                       "(expected digits before or after)", idx)
+
+    def _parse_number(self, idx: int) -> int:
+        idx = self._parse_num_no_exp(idx)
+        if self.get(idx).lower() != 'e':
+            return idx
+        idx += 1
+        # need to handle '-' here explicitly as it is part of the number
+        # so can't just be parsed as a separate operator
+        if self.get(idx) == '-':
+            idx += 1
+        new_idx = self._parse_digit_seq(idx)  # no dot after the 'e'
+        if new_idx is None:
+            # eg: 1.2eC, 8e-Q which is always an error
+            raise self.err("Expected integer after <number>e", idx)
+        idx = new_idx
+        return idx
+
+    def parse(self, start: int) -> Token:
+        return NumberToken(StrRegion(start, self._parse_number(start)))

--- a/parser/lexer/number_parser.py
+++ b/parser/lexer/number_parser.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from string import digits
 
-from parser.common import StrRegion
-from parser.lexer import LocatedMalformedNumberError
-from parser.lexer.src_handler import UsesSrc
-from parser.lexer.tokens import Token, NumberToken
+from .errors import LocatedMalformedNumberError
+from .src_handler import UsesSrc
+from .tokens import Token, NumberToken
+from ..common import StrRegion
 
 
 class NumberParser(UsesSrc):

--- a/parser/lexer/src_handler.py
+++ b/parser/lexer/src_handler.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from .errors import LocatedTokenizerError
+from .tokens import Token
+from ..common import StrRegion, BaseLocatedError, region_union
+
+
+class UsesSrc:
+    def __init__(self, src: str):
+        self.src: str = src
+
+    def __getitem__(self, item: int | slice) -> str:
+        return self.src[item]
+
+    def eof(self, idx: int):
+        return idx >= len(self.src)
+
+    def get(self, idx: int, eof: str = '\0') -> str:
+        try:
+            return self.src[idx]
+        except IndexError:
+            return eof
+
+    default_err_type = LocatedTokenizerError
+
+    def err(self, msg: str,
+            loc: int | Token | StrRegion | Sequence[int | Token | StrRegion],
+            tp: type[BaseLocatedError] = None):
+        try:
+            seq: tuple[int | Token | StrRegion, ...] = tuple(loc)
+        except TypeError:
+            seq = (loc,)
+        region = region_union([
+            StrRegion(o, o + 1) if isinstance(o, int) else o
+            for o in seq])
+        tp = tp or self.default_err_type
+        return tp(msg, region, self.src)

--- a/parser/lexer/token_print.py
+++ b/parser/lexer/token_print.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import sys
+from io import StringIO
+from typing import IO
+
+from .tokens import Token
+
+
+def print_tokens(src: str, tokens: list[Token], stream: IO[str] = None, do_ws=False):
+    if stream is None:
+        stream = sys.stdout
+    table = []
+    for tok in tokens:
+        if tok.is_whitespace:
+            if do_ws:
+                table.append(['(WS) ' + repr(tok.region.resolve(src)), tok.name])
+        else:
+            table.append([str(tok.region.resolve(src)), tok.name])
+    max0 = max(len(r[0]) for r in table)
+    max1 = max(len(r[1]) for r in table)
+    for s0, s1 in table:
+        print(f'{s0:>{max0}} | {s1:>{max1}}', file=stream)
+
+
+def format_tokens(src: str, tokens: list[Token], do_ws=False):
+    out = StringIO()
+    print_tokens(src, tokens, out, do_ws)
+    return out.getvalue()

--- a/parser/lexer/tokenizer.py
+++ b/parser/lexer/tokenizer.py
@@ -3,20 +3,13 @@ from __future__ import annotations
 import sys
 from io import StringIO
 from string import ascii_letters, digits
-from typing import TYPE_CHECKING, IO, Sequence
+from typing import IO, Sequence
 
-from .tokens import (
-    Token, WhitespaceToken, LineCommentToken, BlockCommentToken, NumberToken,
-    StringToken, CommaToken, DotToken, OpToken, PAREN_TYPES,
-    SemicolonToken, AttrNameToken, IdentNameToken,
-    EofToken, RParToken, RSqBracket
-)
+from .tokens import *
 from ..common import StrRegion
 from ..common.error import BaseParseError, BaseLocatedError
 from ..operators import OPS_SET, MAX_OP_LEN, OP_FIRST_CHARS
 
-if TYPE_CHECKING:
-    from .tokens import ParenTokenT
 
 IDENT_START = ascii_letters + '_'
 IDENT_CONT = IDENT_START + digits
@@ -138,7 +131,7 @@ class Tokenizer(SrcHandler):
                 else:
                     idx = self._t_ident_name(idx)
             elif self[idx] in PAREN_TYPES:
-                tp: ParenTokenT = PAREN_TYPES[self[idx]]
+                tp = PAREN_TYPES[self[idx]]
                 idx = self.add_token(tp(StrRegion(idx, idx + 1)))
             elif self[idx:idx+2] == '//':
                 idx = self._t_line_comment(idx)

--- a/parser/lexer/tokenizer.py
+++ b/parser/lexer/tokenizer.py
@@ -5,10 +5,11 @@ from io import StringIO
 from string import ascii_letters, digits
 from typing import IO, Sequence
 
+from .errors import LocatedTokenizerError, LocatedMalformedNumberError
 from .tokens import *
 from .tokens import OpToken, CommaToken
 from ..common import StrRegion, region_union
-from ..common.error import BaseParseError, BaseLocatedError
+from ..common.error import BaseLocatedError
 from ..operators import OPS_SET, MAX_OP_LEN, OP_FIRST_CHARS
 
 
@@ -16,23 +17,7 @@ IDENT_START = ascii_letters + '_'
 IDENT_CONT = IDENT_START + digits
 
 
-class TokenizerError(BaseParseError):
-    ...
-
-
-class LocatedTokenizerError(BaseLocatedError, TokenizerError):
-    ...
-
-
-class MalformedNumberError(TokenizerError):
-    ...
-
-
-class LocatedMalformedNumberError(LocatedTokenizerError, MalformedNumberError):
-    ...
-
-
-class SrcHandler:
+class UsesSrc:
     def __init__(self, src: str):
         self.src: str = src
 
@@ -64,7 +49,7 @@ class SrcHandler:
         return tp(msg, region, self.src)
 
 
-class Tokenizer(SrcHandler):
+class Tokenizer(UsesSrc):
     def __init__(self, src: str):
         super().__init__(src)
         self.tokens: list[Token] = []
@@ -270,7 +255,7 @@ GETATTR_VALID_AFTER_CLS = (
 )
 
 
-class _IncrementalNumberParser(SrcHandler):
+class _IncrementalNumberParser(UsesSrc):
     default_err_type = LocatedMalformedNumberError
 
     # todo 0x, 0b (I refuse to add octal literals) - also hex floats???

--- a/parser/lexer/tokenizer.py
+++ b/parser/lexer/tokenizer.py
@@ -9,7 +9,7 @@ from .tokens import (
     Token, WhitespaceToken, LineCommentToken, BlockCommentToken, NumberToken,
     StringToken, CommaToken, DotToken, OpToken, PAREN_TYPES,
     SemicolonToken, AttrNameToken, IdentNameToken,
-    GETATTR_VALID_AFTER_CLS, EofToken
+    EofToken, RParToken, RSqBracket
 )
 from ..common import StrRegion
 from ..common.error import BaseParseError, BaseLocatedError
@@ -289,6 +289,19 @@ class Tokenizer(SrcHandler):
         while self.get(idx) in IDENT_CONT:
             idx += 1
         return self.add_token(IdentNameToken(StrRegion(start, idx)))
+
+
+GETATTR_VALID_AFTER_CLS = (
+    StringToken,
+    RParToken,
+    RSqBracket,
+    AttrNameToken,
+    IdentNameToken
+    # Not valid (directly) after floats (need parens) because we treat all
+    # numbers the same and we cannot have it after ints
+    #   2.3 => (2).3 (attribute) or `2.3` (float)
+    # Also it would be confusing to have 2.e3 => num, 2.e3.3 -> num.attr.
+)
 
 
 class _IncrementalNumberParser(SrcHandler):

--- a/parser/lexer/tokenizer.py
+++ b/parser/lexer/tokenizer.py
@@ -369,25 +369,6 @@ class _IncrementalNumberParser(SrcHandler):
         return NumberToken(StrRegion(start, idx)), idx
 
 
-def main():
-    import pprint
-    src = ("ab2 = 12==!(  \n" + r"e3.1.2 >= '7\'\\')%12;var x='b'..7")
-    t = Tokenizer(src)
-    t.tokenize()
-    pprint.pp(t.tokens)
-    table = []
-    for tok in t.tokens:
-        if tok.is_whitespace:
-            row = ['(WS) ' + repr(tok.region.resolve(src)), tok.name]
-        else:
-            row = [str(tok.region.resolve(src)), tok.name]
-        table.append(row)
-    max0 = max(len(r[0]) for r in table)
-    max1 = max(len(r[1]) for r in table)
-    for s0, s1 in table:
-        print(f'{s0:>{max0}} {s1:>{max1}}')
-
-
 def print_tokens(src: str, tokens: list[Token], stream: IO[str] = None, do_ws=False):
     if stream is None:
         stream = sys.stdout
@@ -408,7 +389,3 @@ def format_tokens(src: str, tokens: list[Token], do_ws=False):
     out = StringIO()
     print_tokens(src, tokens, out, do_ws)
     return out.getvalue()
-
-
-if __name__ == '__main__':
-    main()

--- a/parser/lexer/tokenizer.py
+++ b/parser/lexer/tokenizer.py
@@ -3,50 +3,17 @@ from __future__ import annotations
 import sys
 from io import StringIO
 from string import ascii_letters, digits
-from typing import IO, Sequence
+from typing import IO
 
-from .errors import LocatedTokenizerError, LocatedMalformedNumberError
+from .errors import LocatedMalformedNumberError
+from .src_handler import UsesSrc
 from .tokens import *
-from .tokens import OpToken, CommaToken
-from ..common import StrRegion, region_union
-from ..common.error import BaseLocatedError
+from ..common import StrRegion
 from ..operators import OPS_SET, MAX_OP_LEN, OP_FIRST_CHARS
 
 
 IDENT_START = ascii_letters + '_'
 IDENT_CONT = IDENT_START + digits
-
-
-class UsesSrc:
-    def __init__(self, src: str):
-        self.src: str = src
-
-    def __getitem__(self, item: int | slice) -> str:
-        return self.src[item]
-
-    def eof(self, idx: int):
-        return idx >= len(self.src)
-
-    def get(self, idx: int, eof: str = '\0') -> str:
-        try:
-            return self.src[idx]
-        except IndexError:
-            return eof
-
-    default_err_type = LocatedTokenizerError
-
-    def err(self, msg: str,
-            loc: int | Token | StrRegion | Sequence[int | Token | StrRegion],
-            tp: type[BaseLocatedError] = None):
-        try:
-            seq: tuple[int | Token | StrRegion, ...] = tuple(loc)
-        except TypeError:
-            seq = (loc,)
-        region = region_union([
-            StrRegion(o, o + 1) if isinstance(o, int) else o
-            for o in seq])
-        tp = tp or self.default_err_type
-        return tp(msg, region, self.src)
 
 
 class Tokenizer(UsesSrc):

--- a/parser/lexer/tokenizer.py
+++ b/parser/lexer/tokenizer.py
@@ -6,7 +6,7 @@ from string import ascii_letters, digits
 from typing import IO, Sequence
 
 from .tokens import *
-from ..common import StrRegion
+from ..common import StrRegion, region_union
 from ..common.error import BaseParseError, BaseLocatedError
 from ..operators import OPS_SET, MAX_OP_LEN, OP_FIRST_CHARS
 
@@ -56,18 +56,10 @@ class SrcHandler:
             seq: tuple[int | Token | StrRegion, ...] = tuple(loc)
         except TypeError:
             seq = (loc,)
-        regs = []
-        for o in seq:
-            if isinstance(o, int):
-                reg = StrRegion(o, o + 1)
-            elif isinstance(o, Token):
-                reg = o.region
-            else:
-                reg = o
-            regs.append(reg)
-        region = StrRegion.including(*regs)
-        if tp is None:
-            tp = self.default_err_type
+        region = region_union([
+            StrRegion(o, o + 1) if isinstance(o, int) else o
+            for o in seq])
+        tp = tp or self.default_err_type
         return tp(msg, region, self.src)
 
 

--- a/parser/lexer/tokenizer.py
+++ b/parser/lexer/tokenizer.py
@@ -5,7 +5,7 @@ from io import StringIO
 from string import ascii_letters, digits
 from typing import IO
 
-from .errors import LocatedMalformedNumberError
+from .number_parser import NumberParser
 from .src_handler import UsesSrc
 from .tokens import *
 from ..common import StrRegion
@@ -170,7 +170,7 @@ class Tokenizer(UsesSrc):
         # doesn't handle negative numbers,
         # those should be handled as a separate '-' operator
         assert self[idx] != '-', "_t_number doesn't handle negative numbers"
-        return self.add_token(_IncrementalNumberParser(self.src).parse(idx))
+        return self.add_token(NumberParser(self.src).parse(idx))
 
     def _t_dot(self, idx: int) -> int:
         assert self[idx] == '.', "_t_dot should only be called if char is '.'"
@@ -220,77 +220,6 @@ GETATTR_VALID_AFTER_CLS = (
     #   2.3 => (2).3 (attribute) or `2.3` (float)
     # Also it would be confusing to have 2.e3 => num, 2.e3.3 -> num.attr.
 )
-
-
-class _IncrementalNumberParser(UsesSrc):
-    default_err_type = LocatedMalformedNumberError
-
-    # todo 0x, 0b (I refuse to add octal literals) - also hex floats???
-    def _parse_digit_seq(self, start: int) -> int | None:
-        # (Returns None if no digits)
-        idx = start
-        if self.get(idx) == '_':
-            raise self.err("Can't have '_' at the start of a number", idx)
-        if self.get(idx) not in digits:
-            return None
-        idx += 1
-        while True:
-            if self.get(idx) == '_':
-                if self.get(idx + 1) in digits:
-                    idx += 2  # '_' and digit
-                elif self.get(idx + 1) == '_':
-                    raise self.err(
-                        "Can only have one consecutive '_' in a number", idx + 1)
-                else:
-                    raise self.err(
-                        "Can't have '_' at the end of a number", idx)
-            elif self.get(idx) in digits:
-                idx += 1
-            else:
-                return idx  # end of digits/'_'
-
-    def _parse_num_no_exp(self, idx: int) -> int:
-        new_idx = self._parse_digit_seq(idx)
-        if new_idx is None:
-            if self.get(idx) != '.':
-                raise self.err("Number must start with digit or '.' ", idx)
-            has_pre_dot = False
-        else:
-            has_pre_dot = True
-            idx = new_idx
-        if self.get(idx) != '.':
-            # eg: 1234, 567e-5, 8 +9-10
-            return idx
-        idx += 1
-        new_idx = self._parse_digit_seq(idx)
-        if new_idx is None:
-            has_post_dot = False
-        else:
-            has_post_dot = True
-            idx = new_idx
-        if has_pre_dot or has_post_dot:
-            return idx
-        raise self.err("Number cannot be a single '.' "
-                       "(expected digits before or after)", idx)
-
-    def _parse_number(self, idx: int) -> int:
-        idx = self._parse_num_no_exp(idx)
-        if self.get(idx).lower() != 'e':
-            return idx
-        idx += 1
-        # need to handle '-' here explicitly as it is part of the number
-        # so can't just be parsed as a separate operator
-        if self.get(idx) == '-':
-            idx += 1
-        new_idx = self._parse_digit_seq(idx)  # no dot after the 'e'
-        if new_idx is None:
-            # eg: 1.2eC, 8e-Q which is always an error
-            raise self.err("Expected integer after <number>e", idx)
-        idx = new_idx
-        return idx
-
-    def parse(self, start: int) -> Token:
-        return NumberToken(StrRegion(start, self._parse_number(start)))
 
 
 def print_tokens(src: str, tokens: list[Token], stream: IO[str] = None, do_ws=False):

--- a/parser/lexer/tokens.py
+++ b/parser/lexer/tokens.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Union, Callable, TYPE_CHECKING
 
 from ..common import HasRegion, StrRegion
 
@@ -92,11 +91,6 @@ class ParenToken(NamedTokenCls):
     side = None  # type: ParenSide
     paren_type = None  # type: ParenType
     paren_str = None  # type: str
-
-
-if TYPE_CHECKING:
-    ParenTokenT = Union[type[ParenToken], Callable[[StrRegion], ParenToken]]
-    __all__.append('ParenTokenT')
 
 
 def register_paren_cls(char: str):

--- a/parser/lexer/tokens.py
+++ b/parser/lexer/tokens.py
@@ -183,16 +183,3 @@ class IdentNameToken(AnyNameToken):
 
 class EofToken(NamedTokenCls):
     name = 'eof'
-
-
-GETATTR_VALID_AFTER_CLS = (
-    StringToken,
-    RParToken,
-    RSqBracket,
-    AttrNameToken,
-    IdentNameToken
-    # Not valid (directly) after floats (need parens) because we treat all
-    # numbers the same and we cannot have it after ints
-    #   2.3 => (2).3 (attribute) or `2.3` (float)
-    # Also it would be confusing to have 2.e3 => num, 2.e3.3 -> num.attr.
-)


### PR DESCRIPTION
Refactor tokenizer - quite a variety of stuff was changed so I won't list it here - see the commits for details.

The most major one is extracting some smaller modules from `lexer.tokenizer` (e.g. `number_parser`).