### PR TITLE
Flatten multiple declarations in AST

### DIFF
--- a/parser/astgen/ast_node.py
+++ b/parser/astgen/ast_node.py
@@ -100,10 +100,11 @@ class AstDeclNode(AstNode):
     name = 'var_decl'
     scope: VarDeclScope
     type: VarType
-    decls: list[tuple[AstIdent, AstNode | None]]
+    ident: AstIdent
+    value: AstNode | None
 
     def _walk_members(self, fn: WalkerFnT):
-        self.walk_multiple_objects(fn, (self.decls,))
+        self.walk_multiple_objects(fn, (self.ident, self.value))
 
 
 @dataclass

--- a/parser/astgen/astgen.py
+++ b/parser/astgen/astgen.py
@@ -134,14 +134,17 @@ class AstGen:
                 f"the root level.", smt.region)
 
     def _walk_var_decl(self, smt: DeclNode):
-        decls = [(self._walk_ident(d.ident),
-                  None if d.value is None else self._walk_expr(d.value))
-                 for d in smt.decl_list.decls]
         scope = (VarDeclScope.LET if isinstance(smt.decl_scope, DeclScope_Let)
                  else VarDeclScope.GLOBAL)
         tp = (VarType.LIST if isinstance(smt.decl_type, DeclType_List)
               else VarType.VARIABLE)
-        return [AstDeclNode(smt.region, scope, tp, decls)]
+        return [self._walk_single_decl(d, scope, tp) for d in smt.decl_list.decls]
+
+    def _walk_single_decl(self, d: DeclItemNode, scope: VarDeclScope, tp: VarType):
+        return AstDeclNode(
+            region_union(d.ident, d.value),
+            scope, tp, self._walk_ident(d.ident),
+            None if d.value is None else self._walk_expr(d.value))
 
     def _walk_assign_left(self, lhs: AnyNode) -> AstNode:
         if isinstance(lhs, IdentNode):

--- a/parser/astgen/astgen.py
+++ b/parser/astgen/astgen.py
@@ -8,7 +8,7 @@ from util import flatten_force, is_strict_subclass
 from .ast_node import *
 from .eval_literal import eval_number, eval_string
 from .errors import LocatedAstError
-from ..common import region_union, RegionUnionArgT, HasRegion
+from ..common import region_union, RegionUnionArgT, HasRegion, StrRegion
 from ..cst.base_node import AnyNode, Node, Leaf
 from ..cst.named_node import NamedLeafCls, NamedNodeCls, NamedSizedNodeCls
 from ..cst.nodes import *
@@ -138,11 +138,17 @@ class AstGen:
                  else VarDeclScope.GLOBAL)
         tp = (VarType.LIST if isinstance(smt.decl_type, DeclType_List)
               else VarType.VARIABLE)
-        return [self._walk_single_decl(d, scope, tp) for d in smt.decl_list.decls]
+        # Add the region from the keywords to first decl (to make single-var
+        # decls a more sensible .region that includes the `let` keyword as well)
+        extra_region_first = region_union(smt.decl_scope, smt.decl_type)
+        return [self._walk_single_decl(d, scope, tp,
+                                       extra_region_first if i == 0 else None)
+                for i, d in enumerate(smt.decl_list.decls)]
 
-    def _walk_single_decl(self, d: DeclItemNode, scope: VarDeclScope, tp: VarType):
+    def _walk_single_decl(self, d: DeclItemNode, scope: VarDeclScope,
+                          tp: VarType, extra_region: StrRegion | None):
         return AstDeclNode(
-            region_union(d.ident, d.value),
+            region_union(d.ident, d.value, extra_region),
             scope, tp, self._walk_ident(d.ident),
             None if d.value is None else self._walk_expr(d.value))
 

--- a/parser/common/common.py
+++ b/parser/common/common.py
@@ -16,6 +16,8 @@ RegionUnionArgT: TypeAlias = RegionUnionFlatT | Sequence[RegionUnionFlatT]
 def region_union(*args: RegionUnionArgT):
     regs = []
     for loc in args:
+        if loc is None:
+            continue
         if getattr(loc, 'region', None) is not None:  # Duck-type HasRegion
             loc = loc.region
         if isinstance(loc, StrRegion):

--- a/test/test_astgen/.snapshots/test_astgen.txt
+++ b/test/test_astgen/.snapshots/test_astgen.txt
@@ -1,4 +1,4 @@
-"2","14","45","93","122","184","192","204","254","321","370"
+"2","14","45","93","122","184","192","204","254","313","358"
 "TestAstGen::test_op_node:0","TestAstGen::test_nop_node:0","TestAstGen::test_aug_assign:0","TestAstGen::test_getattr:0","TestAstGen::test_while_block:0","TestAstGen::test_autocat:0","TestAstGen::test_string_basic:0","TestAstGen::test_unaries:0","TestAstGen::test_decl:0","TestAstGen::test_list_literal_decl:0","TestAstGen::test_list_literal_decl_paren:0"
 AstProgramNode(StrRegion(0, 6),
   [
@@ -254,117 +254,105 @@ AstProgramNode(StrRegion(0, 25),
 )
 AstProgramNode(StrRegion(0, 86),
   [
-    AstDeclNode(StrRegion(0, 13),
+    AstDeclNode(StrRegion(0, 5),
       VarDeclScope.LET,
       VarType.VARIABLE,
-      [
-        (
-          AstIdent(StrRegion(4, 5), 'a'),
-          None
-        ),
-        (
-          AstIdent(StrRegion(6, 7), 'b'),
-          AstBinOp(StrRegion(8, 11),
-            '+',
-            AstNumber(StrRegion(8, 9), 1),
-            AstNumber(StrRegion(10, 11), 1)
-          )
-        ),
-        (
-          AstIdent(StrRegion(12, 13), 'c'),
-          None
-        )
-      ]
+      AstIdent(StrRegion(4, 5), 'a'),
+      None
     ),
-    AstDeclNode(StrRegion(15, 37),
+    AstDeclNode(StrRegion(6, 11),
+      VarDeclScope.LET,
+      VarType.VARIABLE,
+      AstIdent(StrRegion(6, 7), 'b'),
+      AstBinOp(StrRegion(8, 11),
+        '+',
+        AstNumber(StrRegion(8, 9), 1),
+        AstNumber(StrRegion(10, 11), 1)
+      )
+    ),
+    AstDeclNode(StrRegion(12, 13),
+      VarDeclScope.LET,
+      VarType.VARIABLE,
+      AstIdent(StrRegion(12, 13), 'c'),
+      None
+    ),
+    AstDeclNode(StrRegion(15, 34),
       VarDeclScope.GLOBAL,
       VarType.VARIABLE,
-      [
-        (
-          AstIdent(StrRegion(22, 23), 'd'),
-          AstString(StrRegion(26, 34), 'STRING')
-        ),
-        (
-          AstIdent(StrRegion(36, 37), 'e'),
-          None
-        )
-      ]
+      AstIdent(StrRegion(22, 23), 'd'),
+      AstString(StrRegion(26, 34), 'STRING')
     ),
-    AstDeclNode(StrRegion(39, 69),
+    AstDeclNode(StrRegion(36, 37),
+      VarDeclScope.GLOBAL,
+      VarType.VARIABLE,
+      AstIdent(StrRegion(36, 37), 'e'),
+      None
+    ),
+    AstDeclNode(StrRegion(39, 62),
       VarDeclScope.LET,
       VarType.LIST,
-      [
-        (
-          AstIdent(StrRegion(45, 55), 'local_list'),
-          AstCall(StrRegion(56, 62),
-            AstIdent(StrRegion(56, 60), 'list'),
-            []
-          )
-        ),
-        (
-          AstIdent(StrRegion(64, 69), 'other'),
-          None
-        )
-      ]
+      AstIdent(StrRegion(45, 55), 'local_list'),
+      AstCall(StrRegion(56, 62),
+        AstIdent(StrRegion(56, 60), 'list'),
+        []
+      )
+    ),
+    AstDeclNode(StrRegion(64, 69),
+      VarDeclScope.LET,
+      VarType.LIST,
+      AstIdent(StrRegion(64, 69), 'other'),
+      None
     ),
     AstDeclNode(StrRegion(71, 85),
       VarDeclScope.GLOBAL,
       VarType.LIST,
-      [
-        (
-          AstIdent(StrRegion(80, 85), 'STACK'),
-          None
-        )
-      ]
+      AstIdent(StrRegion(80, 85), 'STACK'),
+      None
     )
   ]
 )
 AstProgramNode(StrRegion(0, 63),
   [
-    AstDeclNode(StrRegion(0, 29),
+    AstDeclNode(StrRegion(0, 20),
       VarDeclScope.LET,
       VarType.LIST,
-      [
-        (
-          AstIdent(StrRegion(6, 9), 'loc'),
-          AstListLiteral(StrRegion(12, 20),
-            [
-              AstNumber(StrRegion(13, 14), 5),
-              AstNumber(StrRegion(16, 18), 6.0)
-            ]
-          )
-        ),
-        (
-          AstIdent(StrRegion(22, 23), 'b'),
-          None
-        ),
-        (
-          AstIdent(StrRegion(25, 26), 'c'),
-          AstListLiteral(StrRegion(27, 29),
-            []
-          )
-        )
-      ]
+      AstIdent(StrRegion(6, 9), 'loc'),
+      AstListLiteral(StrRegion(12, 20),
+        [
+          AstNumber(StrRegion(13, 14), 5),
+          AstNumber(StrRegion(16, 18), 6.0)
+        ]
+      )
+    ),
+    AstDeclNode(StrRegion(22, 23),
+      VarDeclScope.LET,
+      VarType.LIST,
+      AstIdent(StrRegion(22, 23), 'b'),
+      None
+    ),
+    AstDeclNode(StrRegion(25, 29),
+      VarDeclScope.LET,
+      VarType.LIST,
+      AstIdent(StrRegion(25, 26), 'c'),
+      AstListLiteral(StrRegion(27, 29),
+        []
+      )
     ),
     AstDeclNode(StrRegion(31, 62),
       VarDeclScope.GLOBAL,
       VarType.LIST,
-      [
-        (
-          AstIdent(StrRegion(41, 46), 'STACK'),
-          AstListLiteral(StrRegion(49, 62),
+      AstIdent(StrRegion(41, 46), 'STACK'),
+      AstListLiteral(StrRegion(49, 62),
+        [
+          AstCall(StrRegion(50, 58),
+            AstIdent(StrRegion(50, 53), 'foo'),
             [
-              AstCall(StrRegion(50, 58),
-                AstIdent(StrRegion(50, 53), 'foo'),
-                [
-                  AstIdent(StrRegion(54, 57), 'bar')
-                ]
-              ),
-              AstNumber(StrRegion(60, 61), 8)
+              AstIdent(StrRegion(54, 57), 'bar')
             ]
-          )
-        )
-      ]
+          ),
+          AstNumber(StrRegion(60, 61), 8)
+        ]
+      )
     )
   ]
 )
@@ -373,16 +361,12 @@ AstProgramNode(StrRegion(0, 16),
     AstDeclNode(StrRegion(0, 15),
       VarDeclScope.LET,
       VarType.LIST,
-      [
-        (
-          AstIdent(StrRegion(6, 7), 'a'),
-          AstListLiteral(StrRegion(11, 14),
-            [
-              AstNumber(StrRegion(12, 13), 1)
-            ]
-          )
-        )
-      ]
+      AstIdent(StrRegion(6, 7), 'a'),
+      AstListLiteral(StrRegion(11, 14),
+        [
+          AstNumber(StrRegion(12, 13), 1)
+        ]
+      )
     )
   ]
 )

--- a/test/test_e2e/.snapshots/test_main_examples.txt
+++ b/test/test_e2e/.snapshots/test_main_examples.txt
@@ -1104,24 +1104,16 @@ AstProgramNode(StrRegion(0, 1683),
     AstDeclNode(StrRegion(0, 19),
       VarDeclScope.GLOBAL,
       VarType.LIST,
-      [
-        (
-          AstIdent(StrRegion(9, 14), 'stack'),
-          AstListLiteral(StrRegion(17, 19),
-            []
-          )
-        )
-      ]
+      AstIdent(StrRegion(9, 14), 'stack'),
+      AstListLiteral(StrRegion(17, 19),
+        []
+      )
     ),
     AstDeclNode(StrRegion(21, 46),
       VarDeclScope.GLOBAL,
       VarType.VARIABLE,
-      [
-        (
-          AstIdent(StrRegion(28, 38), 'COUNT_REFS'),
-          AstIdent(StrRegion(41, 46), 'false')
-        )
-      ]
+      AstIdent(StrRegion(28, 38), 'COUNT_REFS'),
+      AstIdent(StrRegion(41, 46), 'false')
     ),
     AstDefine(StrRegion(396, 506),
       AstIdent(StrRegion(400, 407), 'POP_TOP'),
@@ -1168,30 +1160,22 @@ AstProgramNode(StrRegion(0, 1683),
         AstDeclNode(StrRegion(528, 552),
           VarDeclScope.LET,
           VarType.VARIABLE,
-          [
-            (
-              AstIdent(StrRegion(532, 539), 'tos_idx'),
-              AstCall(StrRegion(542, 552),
-                AstIdent(StrRegion(542, 545), 'len'),
-                [
-                  AstIdent(StrRegion(546, 551), 'stack')
-                ]
-              )
-            )
-          ]
+          AstIdent(StrRegion(532, 539), 'tos_idx'),
+          AstCall(StrRegion(542, 552),
+            AstIdent(StrRegion(542, 545), 'len'),
+            [
+              AstIdent(StrRegion(546, 551), 'stack')
+            ]
+          )
         ),
         AstDeclNode(StrRegion(558, 583),
           VarDeclScope.LET,
           VarType.VARIABLE,
-          [
-            (
-              AstIdent(StrRegion(562, 566), 'tos0'),
-              AstItem(StrRegion(569, 583),
-                AstIdent(StrRegion(569, 574), 'stack'),
-                AstIdent(StrRegion(575, 582), 'tos_idx')
-              )
-            )
-          ]
+          AstIdent(StrRegion(562, 566), 'tos0'),
+          AstItem(StrRegion(569, 583),
+            AstIdent(StrRegion(569, 574), 'stack'),
+            AstIdent(StrRegion(575, 582), 'tos_idx')
+          )
         ),
         AstAssign(StrRegion(589, 624),
           AstItem(StrRegion(589, 603),
@@ -1227,30 +1211,22 @@ AstProgramNode(StrRegion(0, 1683),
         AstDeclNode(StrRegion(795, 819),
           VarDeclScope.LET,
           VarType.VARIABLE,
-          [
-            (
-              AstIdent(StrRegion(799, 806), 'tos_idx'),
-              AstCall(StrRegion(809, 819),
-                AstIdent(StrRegion(809, 812), 'len'),
-                [
-                  AstIdent(StrRegion(813, 818), 'stack')
-                ]
-              )
-            )
-          ]
+          AstIdent(StrRegion(799, 806), 'tos_idx'),
+          AstCall(StrRegion(809, 819),
+            AstIdent(StrRegion(809, 812), 'len'),
+            [
+              AstIdent(StrRegion(813, 818), 'stack')
+            ]
+          )
         ),
         AstDeclNode(StrRegion(825, 850),
           VarDeclScope.LET,
           VarType.VARIABLE,
-          [
-            (
-              AstIdent(StrRegion(829, 833), 'tos0'),
-              AstItem(StrRegion(836, 850),
-                AstIdent(StrRegion(836, 841), 'stack'),
-                AstIdent(StrRegion(842, 849), 'tos_idx')
-              )
-            )
-          ]
+          AstIdent(StrRegion(829, 833), 'tos0'),
+          AstItem(StrRegion(836, 850),
+            AstIdent(StrRegion(836, 841), 'stack'),
+            AstIdent(StrRegion(842, 849), 'tos_idx')
+          )
         ),
         AstAssign(StrRegion(856, 891),
           AstItem(StrRegion(856, 870),
@@ -1304,20 +1280,16 @@ AstProgramNode(StrRegion(0, 1683),
         AstDeclNode(StrRegion(992, 1021),
           VarDeclScope.LET,
           VarType.VARIABLE,
-          [
-            (
-              AstIdent(StrRegion(996, 1001), 'value'),
-              AstItem(StrRegion(1004, 1021),
-                AstIdent(StrRegion(1004, 1009), 'stack'),
-                AstCall(StrRegion(1010, 1020),
-                  AstIdent(StrRegion(1010, 1013), 'len'),
-                  [
-                    AstIdent(StrRegion(1014, 1019), 'stack')
-                  ]
-                )
-              )
+          AstIdent(StrRegion(996, 1001), 'value'),
+          AstItem(StrRegion(1004, 1021),
+            AstIdent(StrRegion(1004, 1009), 'stack'),
+            AstCall(StrRegion(1010, 1020),
+              AstIdent(StrRegion(1010, 1013), 'len'),
+              [
+                AstIdent(StrRegion(1014, 1019), 'stack')
+              ]
             )
-          ]
+          )
         ),
         AstCall(StrRegion(1027, 1046),
           AstAttribute(StrRegion(1027, 1039),
@@ -1349,47 +1321,35 @@ AstProgramNode(StrRegion(0, 1683),
         AstDeclNode(StrRegion(1124, 1148),
           VarDeclScope.LET,
           VarType.VARIABLE,
-          [
-            (
-              AstIdent(StrRegion(1128, 1135), 'tos_idx'),
-              AstCall(StrRegion(1138, 1148),
-                AstIdent(StrRegion(1138, 1141), 'len'),
-                [
-                  AstIdent(StrRegion(1142, 1147), 'stack')
-                ]
-              )
-            )
-          ]
+          AstIdent(StrRegion(1128, 1135), 'tos_idx'),
+          AstCall(StrRegion(1138, 1148),
+            AstIdent(StrRegion(1138, 1141), 'len'),
+            [
+              AstIdent(StrRegion(1142, 1147), 'stack')
+            ]
+          )
         ),
         AstDeclNode(StrRegion(1154, 1179),
           VarDeclScope.LET,
           VarType.VARIABLE,
-          [
-            (
-              AstIdent(StrRegion(1158, 1162), 'tos0'),
-              AstItem(StrRegion(1165, 1179),
-                AstIdent(StrRegion(1165, 1170), 'stack'),
-                AstIdent(StrRegion(1171, 1178), 'tos_idx')
-              )
-            )
-          ]
+          AstIdent(StrRegion(1158, 1162), 'tos0'),
+          AstItem(StrRegion(1165, 1179),
+            AstIdent(StrRegion(1165, 1170), 'stack'),
+            AstIdent(StrRegion(1171, 1178), 'tos_idx')
+          )
         ),
         AstDeclNode(StrRegion(1185, 1214),
           VarDeclScope.LET,
           VarType.VARIABLE,
-          [
-            (
-              AstIdent(StrRegion(1189, 1193), 'tos1'),
-              AstItem(StrRegion(1196, 1214),
-                AstIdent(StrRegion(1196, 1201), 'stack'),
-                AstBinOp(StrRegion(1202, 1213),
-                  '-',
-                  AstIdent(StrRegion(1202, 1209), 'tod_idx'),
-                  AstNumber(StrRegion(1212, 1213), 1)
-                )
-              )
+          AstIdent(StrRegion(1189, 1193), 'tos1'),
+          AstItem(StrRegion(1196, 1214),
+            AstIdent(StrRegion(1196, 1201), 'stack'),
+            AstBinOp(StrRegion(1202, 1213),
+              '-',
+              AstIdent(StrRegion(1202, 1209), 'tod_idx'),
+              AstNumber(StrRegion(1212, 1213), 1)
             )
-          ]
+          )
         ),
         AstCall(StrRegion(1220, 1238),
           AstAttribute(StrRegion(1220, 1232),
@@ -1436,30 +1396,22 @@ AstProgramNode(StrRegion(0, 1683),
         AstDeclNode(StrRegion(1453, 1477),
           VarDeclScope.LET,
           VarType.VARIABLE,
-          [
-            (
-              AstIdent(StrRegion(1457, 1464), 'tos_idx'),
-              AstCall(StrRegion(1467, 1477),
-                AstIdent(StrRegion(1467, 1470), 'len'),
-                [
-                  AstIdent(StrRegion(1471, 1476), 'stack')
-                ]
-              )
-            )
-          ]
+          AstIdent(StrRegion(1457, 1464), 'tos_idx'),
+          AstCall(StrRegion(1467, 1477),
+            AstIdent(StrRegion(1467, 1470), 'len'),
+            [
+              AstIdent(StrRegion(1471, 1476), 'stack')
+            ]
+          )
         ),
         AstDeclNode(StrRegion(1483, 1504),
           VarDeclScope.LET,
           VarType.VARIABLE,
-          [
-            (
-              AstIdent(StrRegion(1487, 1491), 'tos0'),
-              AstItem(StrRegion(1494, 1504),
-                AstIdent(StrRegion(1494, 1499), 'stack'),
-                AstIdent(StrRegion(1500, 1503), 'tos')
-              )
-            )
-          ]
+          AstIdent(StrRegion(1487, 1491), 'tos0'),
+          AstItem(StrRegion(1494, 1504),
+            AstIdent(StrRegion(1494, 1499), 'stack'),
+            AstIdent(StrRegion(1500, 1503), 'tos')
+          )
         ),
         AstAssign(StrRegion(1510, 1545),
           AstItem(StrRegion(1510, 1524),


### PR DESCRIPTION
- Flatten multiple variable declarations in AST, fixes #61 

(Transform (the AST equivalents of) `let a, b=9;` into `let a; let b=9;`)